### PR TITLE
Fix EmailSender import

### DIFF
--- a/MailToolsBox/__init__.py
+++ b/MailToolsBox/__init__.py
@@ -1,2 +1,4 @@
-from MailToolsBox.mailSender import SendAgent
+from MailToolsBox.mailSender import EmailSender, SendAgent
 from MailToolsBox.imapClient import ImapAgent
+
+__all__ = ["EmailSender", "SendAgent", "ImapAgent"]


### PR DESCRIPTION
## Summary
- expose `EmailSender` in package initializer

## Testing
- `python -m pip install -e .` *(fails: Could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68447df7e5f8832f8a8e71ade7c532eb