### PR TITLE
Fix template loader path

### DIFF
--- a/MailToolsBox/mailSender.py
+++ b/MailToolsBox/mailSender.py
@@ -33,8 +33,9 @@ class EmailSender:
         self.port = port
         self.timeout = timeout
         self.validate_emails = validate_emails
+        template_dir = Path(__file__).resolve().parent / "templates"
         self.template_env = Environment(
-            loader=FileSystemLoader('templates'),
+            loader=FileSystemLoader(str(template_dir)),
             autoescape=select_autoescape(['html', 'xml'])
         )
         self.ssl_context = create_default_context()


### PR DESCRIPTION
## Summary
- resolve Jinja2 templates relative to package path

## Testing
- `python -m py_compile MailToolsBox/mailSender.py`
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6844808c4918832fab60117da18e5a96