### PR TITLE
Fix logger configuration

### DIFF
--- a/MailToolsBox/mailSender.py
+++ b/MailToolsBox/mailSender.py
@@ -10,9 +10,9 @@ import logging
 from ssl import create_default_context
 from email_validator import validate_email, EmailNotValidError
 
-# Set up logging
+# Set up logging without configuring the root logger
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logger.addHandler(logging.NullHandler())
 
 
 class EmailSender:


### PR DESCRIPTION
## Summary
- set up a `NullHandler` for MailToolsBox logger
- remove `logging.basicConfig()` call to avoid affecting application logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844808cc020832fbbfbd255fea520fd