### PR TITLE
Add BCC support for send_template

### DIFF
--- a/MailToolsBox/mailSender.py
+++ b/MailToolsBox/mailSender.py
@@ -209,6 +209,7 @@ class EmailSender:
             template_name: str,
             context: dict,
             cc: Optional[Iterable[str]] = None,
+            bcc: Optional[Iterable[str]] = None,
             attachments: Optional[Iterable[str]] = None,
             use_tls: bool = True
     ) -> None:
@@ -216,7 +217,16 @@ class EmailSender:
         logger.info("Sending templated email to %s using %s", recipient, template_name)
         template = self.template_env.get_template(template_name)
         html_content = template.render(**context)
-        self.send([recipient], subject, html_content, cc=cc, attachments=attachments, use_tls=use_tls, html=True)
+        self.send(
+            [recipient],
+            subject,
+            html_content,
+            cc=cc,
+            bcc=bcc,
+            attachments=attachments,
+            use_tls=use_tls,
+            html=True,
+        )
 
 
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ sender.send_template(
     recipient="recipient@example.com",
     subject="Welcome to Our Service",
     template_name="welcome.html",
-    context=context
+    context=context,
+    bcc=["bcc@example.com"]
 )
 ```
 

--- a/tests/test_mail_sender.py
+++ b/tests/test_mail_sender.py
@@ -98,3 +98,33 @@ def test_send_bulk(monkeypatch):
     assert sent == ["a@example.com", "b@example.com"]
 
 
+def test_send_template_passes_bcc(monkeypatch):
+    sender = EmailSender(
+        user_email="user@example.com",
+        server_smtp_address="smtp.example.com",
+        user_email_password="pass",
+        port=25,
+    )
+
+    captured = {}
+
+    def fake_send(recipients, subject, message_body, **kwargs):
+        captured["recipients"] = recipients
+        captured.update(kwargs)
+
+    monkeypatch.setattr(sender, "send", fake_send)
+
+    sender.send_template(
+        recipient="to@example.com",
+        subject="Subj",
+        template_name="tmpl.html",
+        context={},
+        cc=["cc@example.com"],
+        bcc=["bcc@example.com"],
+    )
+
+    assert captured["recipients"] == ["to@example.com"]
+    assert captured["bcc"] == ["bcc@example.com"]
+    assert captured["cc"] == ["cc@example.com"]
+
+


### PR DESCRIPTION
## Summary
- allow `EmailSender.send_template()` to take a `bcc` argument
- document BCC usage in the README
- test that templated emails forward the `bcc` list correctly

## Testing
- `python -m pytest -q`