### PR TITLE
Use os.path.join for downloads

### DIFF
--- a/MailToolsBox/imapClient.py
+++ b/MailToolsBox/imapClient.py
@@ -53,7 +53,8 @@ class ImapAgent:
         if self.mail is None:
             self.login_account()
 
-        with open(f'{path}email.txt', 'w') as f:
+        file_path = os.path.join(path, 'email.txt')
+        with open(file_path, 'w') as f:
             self.mail.select(mailbox)
             _, data = self.mail.uid('search', None, 'ALL')
             uids = data[0].split()
@@ -136,7 +137,8 @@ class ImapAgent:
         mail_items_json = json.dumps(mail_items)
 
         if save_json:
-            with open(f"{path}{file_name}", 'w') as f:
+            file_path = os.path.join(path, file_name)
+            with open(file_path, 'w') as f:
                 f.write(mail_items_json)
 
         return mail_items_json
@@ -149,7 +151,7 @@ class ImapAgent:
                 'fetch', latest_email_uid, '(RFC822)')
             raw_email = email_data[0][1]
             email_message = email.message_from_bytes(raw_email)
-            file_name = f"{path}email_{i}.msg"
+            file_name = os.path.join(path, f"email_{i}.msg")
             with open(file_name, 'w') as f:
                 f.write(email_message.as_string())
         self.mail.close()

--- a/tests/test_imap_agent.py
+++ b/tests/test_imap_agent.py
@@ -77,13 +77,15 @@ def test_login_account(monkeypatch):
     assert dummy.logged_in
 
 
-def test_download_mail_text(tmp_path, monkeypatch):
+@pytest.mark.parametrize("trailing", [True, False])
+def test_download_mail_text(tmp_path, monkeypatch, trailing):
     message_bytes = sample_message_bytes()
     dummy = DummyMail(message_bytes)
     agent = ImapAgent('user', 'pass', 'imap.example.com')
     agent.mail = dummy
 
-    agent.download_mail_text(path=str(tmp_path) + os.sep)
+    path = str(tmp_path) + (os.sep if trailing else "")
+    agent.download_mail_text(path=path)
 
     file_path = tmp_path / 'email.txt'
     assert file_path.exists()
@@ -92,14 +94,16 @@ def test_download_mail_text(tmp_path, monkeypatch):
     assert dummy.closed
 
 
-def test_download_mail_json(tmp_path, monkeypatch):
+@pytest.mark.parametrize("trailing", [True, False])
+def test_download_mail_json(tmp_path, monkeypatch, trailing):
     message_bytes = sample_message_bytes()
     dummy = DummyMail(message_bytes)
     monkeypatch.setattr(ImapAgent, 'login_account', lambda self: None)
     monkeypatch.setattr('imaplib.IMAP4_SSL', lambda addr: dummy)
 
     agent = ImapAgent('user', 'pass', 'imap.example.com')
-    result = agent.download_mail_json(save=True, path=str(tmp_path) + os.sep)
+    path = str(tmp_path) + (os.sep if trailing else "")
+    result = agent.download_mail_json(save=True, path=path)
 
     data = json.loads(result)
     assert isinstance(data, list)
@@ -109,13 +113,15 @@ def test_download_mail_json(tmp_path, monkeypatch):
     assert dummy.closed
 
 
-def test_download_mail_msg(tmp_path):
+@pytest.mark.parametrize("trailing", [True, False])
+def test_download_mail_msg(tmp_path, trailing):
     message_bytes = sample_message_bytes()
     dummy = DummyMail(message_bytes)
     agent = ImapAgent('user', 'pass', 'imap.example.com')
     agent.login_account = lambda: setattr(agent, 'mail', dummy)
 
-    agent.download_mail_msg(path=str(tmp_path) + os.sep)
+    path = str(tmp_path) + (os.sep if trailing else "")
+    agent.download_mail_msg(path=path)
 
     file_path = tmp_path / 'email_0.msg'
     assert file_path.exists()


### PR DESCRIPTION
## Summary
- handle path concatenation with `os.path.join`
- test with and without trailing separators when saving IMAP messages

## Testing
- `pytest -q`