### PR TITLE
Add async attachment support

### DIFF
--- a/tests/test_imap_agent.py
+++ b/tests/test_imap_agent.py
@@ -13,6 +13,11 @@ sys.modules.setdefault(
     "aiosmtplib",
     types.SimpleNamespace(SMTP=None, errors=types.SimpleNamespace(SMTPException=Exception)),
 )
+# Minimal stub for aiofiles used by mailSender imports
+sys.modules.setdefault(
+    "aiofiles",
+    types.SimpleNamespace(open=lambda *args, **kwargs: None),
+)
 # Minimal stub for jinja2 used by EmailSender imports
 sys.modules.setdefault(
     "jinja2",


### PR DESCRIPTION
## Summary
- support async attachment handling in `EmailSender`
- use async attachment method in `send_async`
- add tests for async sending and attachment handling
