### PR TITLE
Write email data to .msg as bytes

### DIFF
--- a/MailToolsBox/imapClient.py
+++ b/MailToolsBox/imapClient.py
@@ -152,7 +152,7 @@ class ImapAgent:
             raw_email = email_data[0][1]
             email_message = email.message_from_bytes(raw_email)
             file_name = os.path.join(path, f"email_{i}.msg")
-            with open(file_name, 'w') as f:
-                f.write(email_message.as_string())
+            with open(file_name, 'wb') as f:
+                f.write(email_message.as_bytes())
         self.mail.close()
         self.logout_account()


### PR DESCRIPTION
## Summary
- ensure `.msg` files are opened in binary mode
- write byte representation of fetched email

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456b90a188832fa7a3ac88d29371de