### PR TITLE
Update gitignore, remove vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ MailToolsBox.egg-info/PKG-INFO
 MailToolsBox.egg-info/requires.txt
 MailToolsBox.egg-info/SOURCES.txt
 MailToolsBox.egg-info/top_level.txt
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+.vscode/
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}


### PR DESCRIPTION
## Summary
- ignore build artifacts, egg-info, pycache, and editor configs
- remove `.vscode` from version control